### PR TITLE
Version bump Hugo to 0.34

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get -qq update \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Download and install hugo
-ENV HUGO_VERSION 0.33
+ENV HUGO_VERSION 0.34
 ENV HUGO_BINARY hugo_${HUGO_VERSION}_Linux-64bit.deb
 
 #ADD https://github.com/spf13/hugo/releases/download/v${HUGO_VERSION}/${HUGO_BINARY} /tmp/hugo.deb


### PR DESCRIPTION
Hugo 0.34 was released over a week ago. This PR simply Bumps the version of Hugo to match this.