### PR TITLE
Updates to the current stable release of Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 # Install pygments (for syntax highlighting) 
 RUN apt-get -qq update \


### PR DESCRIPTION
Jessie is listed as an obsolete stable release on the [Debian releases page](https://www.debian.org/releases/). Stretch is the latest stable release.