### PR TITLE
added asciidoctor to apt-get install command. this allows .adoc files…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:stretch
 
 # Install pygments (for syntax highlighting) 
 RUN apt-get -qq update \
-	&& DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends libstdc++6 python-pygments git ca-certificates asciidoc curl \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends libstdc++6 python-pygments git ca-certificates asciidoc asciidoctor curl \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Configuration variables


### PR DESCRIPTION
… to not generate errors

asciidoc: ERROR: <stdin>: line 4: unsafe: ifeval invalid