### PR TITLE
add argument HUGO_APPEND_PORT so user can disable it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,6 @@ ONBUILD RUN hugo -d /usr/share/nginx/html/
 
 # By default, serve site
 ENV HUGO_BASE_URL http://localhost:1313
-CMD hugo server -b ${HUGO_BASE_URL} --bind=0.0.0.0
+# By default, append port
+ENV HUGO_APPEND_PORT true
+CMD hugo server -b ${HUGO_BASE_URL} --appendPort=${HUGO_APPEND_PORT} --bind=0.0.0.0

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ This will automatically start `hugo server`, and your blog is now available on h
 If you are using `boot2docker`, you need to adjust the base URL: 
 
 	docker run -p 1313:1313 -e HUGO_BASE_URL=http://YOUR_DOCKER_IP:1313 monachus/hugo
+	
+If you want to change use a proxy (like `letsencrypt-nginx-proxy-companion`), you need to disable the port
+
+	docker run [...lets-encrypt-arg...] -e HUGO_BASE_URL=https://my.domain.name -e HUGO_APPEND_PORT=false monachus/hugo
 
 The image is also suitable for use as a volume image for a web server, such as [nginx](https://registry.hub.docker.com/_/nginx/)
 


### PR DESCRIPTION
In order to use this image with the lets-encrypt-proxy-companion, you need to disable the 'appendPort', otherwise somes features don't work (the search results are linked to `my.domain.name:1313/something`). 

I set the default value set as `true` because it's the default value for it according to the documentation. So if you don't add the environment variable, nothing is changed. 
