### PR TITLE
version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get -qq update \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Configuration variables
-ENV HUGO_VERSION 0.57.1
+ENV HUGO_VERSION 0.57.2
 ENV HUGO_BINARY hugo_extended_${HUGO_VERSION}_Linux-64bit.deb
 ENV SITE_DIR '/usr/share/blog'
 


### PR DESCRIPTION
I started using this Docker image for my GitLab hosted site and because of the current version, it's currently broken. Please see release notes: https://github.com/gohugoio/hugo/releases/tag/v0.57.2