### PR TITLE
Add ssh to apt-install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:buster
 
 # Install pygments (for syntax highlighting) 
 RUN apt-get -qq update \
-	&& DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends libstdc++6 python-pygments git ca-certificates asciidoc curl \
+	&& DEBIAN_FRONTEND=noninteractive apt-get -qq install -y --no-install-recommends libstdc++6 python-pygments git ssh ca-certificates asciidoc curl \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Configuration variables


### PR DESCRIPTION
The image currently only supports repositories over HTTP protocol.
This allows using git ssh repositories in the format of `git@...`

Edit (additional context):
This is useful when themes are added as submodules and remotes are added as ssh repositories.